### PR TITLE
Add test discovery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.0
+
+* Add ability to configure location of Python tests based on project root.
+
 ## 0.2.0
 
 * Fix an issue where unavailable tools were still considered available when checking for environments.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,25 @@ This extension relies on the official [Python VS Code extension](https://marketp
 
 ## Extension Settings
 
-This extension does not expose any settings.
+### `python.testing.cwdTemplate`
+
+Default: `null`
+  
+If set, update the `python.testing.cwd` setting used by the Python extension to discover tests based on the active project.
+Use `${projectRoot}` as a placeholder for the root directory of the active project.
+
+For example, use `${projectRoot}/tests` to locate tests in a tests directory:
+
+```
+project1/
+    project1/
+        __init__.py
+        code.py
+    tests/
+        __init__.py
+        test_code.py
+    pyproject.toml
+```
 
 ## Known Issues
 
@@ -36,6 +54,10 @@ If the environment for a given file has changed, the `Activate Python Environmen
 Manually created virtual environments are currently not supported.
 
 ## Release Notes
+
+### 0.3.0
+
+Add ability to configure location of Python tests based on project root.
 
 ### 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Python Venv Switcher",
   "description": "Automatic virtual environment switching for Python monorepos.",
   "icon": "icons/icon.png",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "wmiller4",
   "repository": {
     "url": "https://github.com/wmiller4/python-venv-switcher"
@@ -28,7 +28,17 @@
         "command": "python-venv-switcher.setEnvironment",
         "title": "Activate Python Environment"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Python Venv Switcher",
+      "properties": {
+        "python.testing.cwdTemplate": {
+          "type": "string",
+          "default": null,
+          "description": "Template for resolving the working directory for Python tests. Use `${projectRoot}` as a placeholder for the project root."
+        }
+      }
+    }
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -4,6 +4,7 @@ import path from "path";
 import * as vscode from 'vscode';
 import logger from './logger';
 import { VenvProvider } from "./providers";
+import { setTestingCwd } from "./testing";
 
 type PythonEnvironment = {
 	providerName: string
@@ -65,9 +66,13 @@ export class EnvironmentManager {
 		}
 		if (this.activeEnvironment === targetEnvironment.pythonPath) {
 			logger.debug('Target virtual environment is already active.');
+			if (ignoreCache) {
+				setTestingCwd(editor);
+			}
 			return;
 		}
-		this.pythonApi.environments.updateActiveEnvironmentPath(targetEnvironment.pythonPath);
+		await this.pythonApi.environments.updateActiveEnvironmentPath(targetEnvironment.pythonPath);
 		logger.info(`Activated ${targetEnvironment.providerName} environment ${targetEnvironment.pythonPath}`);
+		await setTestingCwd(editor);
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		await PythonExtension.api(),
 		new EnvironmentLookup(await availableProviders())
 	);
-	envManager.setEnvironment(vscode.window.activeTextEditor);
+	envManager.setEnvironment(vscode.window.activeTextEditor, true);
 
 	const command = vscode.commands.registerCommand('python-venv-switcher.setEnvironment', () => {
 		envManager.setEnvironment(vscode.window.activeTextEditor, true);

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+import path from "path";
+import fs from "fs";
+import logger from "./logger";
+
+function projectRoot(filePath: string): string | undefined {
+    if (!vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath))) {
+        return undefined;
+    }
+    if (fs.existsSync(path.resolve(filePath, 'pyproject.toml'))) {
+        return filePath;
+    }
+    if (fs.existsSync(path.resolve(filePath, 'Pipfile'))) {
+        return filePath;
+    }
+    return projectRoot(path.resolve(filePath, '..'));
+}
+
+function cwd(template: string, projectRoot: string): string | undefined {
+    const result = template.replaceAll('${projectRoot}', projectRoot);
+    if (!fs.existsSync(result)) {
+        logger.info(`Test directory ${result} not found`);
+        return undefined;
+    }
+    return result;
+}
+
+export async function setTestingCwd(editor?: vscode.TextEditor) {
+    if (!editor) { return; }
+
+    const testing = vscode.workspace.getConfiguration('python.testing');
+    const template = testing.get<string>('cwdTemplate');
+    if (!template || template.trim() === '') {
+        logger.debug('python.testing.cwdTemplate not found.');
+        return;
+    }
+
+    const root = projectRoot(editor.document.uri.fsPath);
+    const testsDir = root ? cwd(template, root) : undefined;
+    await testing.update('cwd', testsDir);
+    logger.info(`Set python.testing.cwdTemplate to ${testsDir}`);
+}


### PR DESCRIPTION
This PR adds an optional feature to update the `python.testing.cwd` setting used by the Python plugin for test discovery based on the active project. It works by taking a template and replacing `${projectRoot}` with the root directory of the project (the nearest ancestor containing pyproject.toml or Pipfile). This value is not set by default, and should not modify the cwd setting unless the user explicitly enables this feature.