### PR TITLE
Improve test configuration in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.1
+
+* Update readme.
+
 ## 0.3.0
 
 * Add ability to configure location of Python tests based on project root.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ This extension supports virtual environments managed by:
 Since this extension queries the tool to locate the environment, environments can live outside of the VS Code workspace.
 
 Multiple environments for a single file are supported.
-Use your tool to switch environments (such as `poetry env use` for Poetry). Then run the `Activate Python Environment` command in VS Code to pick up the new environment.
+Use your tool to switch environments (such as `poetry env use` for Poetry).
+Then run the `Activate Python Environment` command in VS Code to pick up the new environment.
+
+The working directory for Python test discovery can be configured based on the active environment.
 
 ## Requirements
 
@@ -31,7 +34,7 @@ Default: `null`
 If set, update the `python.testing.cwd` setting used by the Python extension to discover tests based on the active project.
 Use `${projectRoot}` as a placeholder for the root directory of the active project.
 
-For example, use `${projectRoot}/tests` to locate tests in a tests directory:
+For example, use `${projectRoot}` to locate tests in a tests directory:
 
 ```
 project1/
@@ -54,6 +57,10 @@ If the environment for a given file has changed, the `Activate Python Environmen
 Manually created virtual environments are currently not supported.
 
 ## Release Notes
+
+### 0.3.1
+
+Update readme.
 
 ### 0.3.0
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "displayName": "Python Venv Switcher",
   "description": "Automatic virtual environment switching for Python monorepos.",
   "icon": "icons/icon.png",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "wmiller4",
+  "homepage": "https://irregular-expressions.net/switcher",
   "repository": {
     "url": "https://github.com/wmiller4/python-venv-switcher"
   },
@@ -16,7 +17,7 @@
     "Other"
   ],
   "keywords": [
-    "monorepo", "pdm", "pipenv", "poetry", "venv"
+    "monorepo", "pdm", "pipenv", "poetry", "python", "venv"
   ],
   "activationEvents": [
     "onLanguage:python"
@@ -54,6 +55,12 @@
     "package": "vsce package --no-dependencies",
     "publish": "vsce publish --no-dependencies"
   },
+  "dependencies": {
+    "@vscode/python-extension": "^1.0.5"
+  },
+  "extensionDependencies": [
+    "ms-python.python"
+  ],
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
@@ -67,8 +74,5 @@
     "eslint": "^8.57.0",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0",
-  "dependencies": {
-    "@vscode/python-extension": "^1.0.5"
-  }
+  "packageManager": "pnpm@9.1.4+sha512.9df9cf27c91715646c7d675d1c9c8e41f6fce88246f1318c1aa6a1ed1aeb3c4f032fcdf4ba63cc69c4fe6d634279176b5358727d8f2cc1e65b65f43ce2f8bfb0"
 }


### PR DESCRIPTION
Recommend using `${projectRoot}` even if tests are in a subdirectory. Pytest will still pick up the tests, and VS Code will use the project name instead of "tests" as the root node in the Tests panel. This makes it easier to identify the current project's tests since the Tests panel accumulates tests from multiple projects when switching environments.
