### PR TITLE
Create a workspace if needed to set the Python interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.0
+
+* Add ability to create a workspace if needed to activate a virtual environment.
+
 ## 0.4.2
 
 * Update tar-fs, undici.
@@ -25,7 +29,6 @@
 ## 0.2.0
 
 * Fix an issue where unavailable tools were still considered available when checking for environments.
-
 * Add logging.
 
 ## 0.1.1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Supports most project layouts:
 
 ## Settings
 
+### Create Workspace
+
+Setting key: `python.venv.switcher.createWorkspace`
+
+VS Code only allows a virtual environment to be set if a workspace is open.
+When an environment is detected for an open file but no workspace is open,
+this setting controls whether a new workspace is created to activate the virtual environment.
+
 ### Custom Provider
 
 Setting key: `python.venv.switcher.customProvider`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Python Venv Switcher",
   "description": "Automatic virtual environment switching for Python monorepos.",
   "icon": "icons/icon.png",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "publisher": "wmiller4",
   "homepage": "https://irregular-expressions.net/switcher",
   "repository": {
@@ -42,12 +42,6 @@
     "configuration": {
       "title": "Python Venv Switcher",
       "properties": {
-        "python.testing.cwdTemplate": {
-          "title": "Working Directory Template",
-          "description": "Template for resolving the working directory for Python tests. Use `${projectRoot}` as a placeholder for the project root.",
-          "type": "string",
-          "default": null
-        },
         "python.venv.switcher.createWorkspace": {
           "title": "Create Workspace",
           "description": "Whether a new workspace should be created if needed to activate a Python environment.",
@@ -62,6 +56,12 @@
         "python.venv.switcher.customProvider": {
           "title": "Tool",
           "description": "A command that returns the full path to the virtual environment's Python executable. If set, overrides the default environment resolution logic.",
+          "type": "string",
+          "default": null
+        },
+        "python.testing.cwdTemplate": {
+          "title": "Working Directory Template",
+          "description": "Template for resolving the working directory for Python tests. Use `${projectRoot}` as a placeholder for the project root.",
           "type": "string",
           "default": null
         }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,17 @@
           "type": "string",
           "default": null
         },
+        "python.venv.switcher.createWorkspace": {
+          "title": "Create Workspace",
+          "description": "Whether a new workspace should be created if needed to activate a Python environment.",
+          "type": "string",
+          "default": "ask",
+          "enum": [
+            "always",
+            "ask",
+            "never"
+          ]
+        },
         "python.venv.switcher.customProvider": {
           "title": "Tool",
           "description": "A command that returns the full path to the virtual environment's Python executable. If set, overrides the default environment resolution logic.",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -3,8 +3,10 @@ import fs, { PathLike } from "fs";
 import path from "path";
 import * as vscode from 'vscode';
 import logger from './logger';
+import paths from "./paths";
 import { VenvProvider } from "./providers";
 import { setTestingCwd } from "./testing";
+import workspace from "./workspace";
 
 type PythonEnvironment = {
 	providerName: string
@@ -71,8 +73,15 @@ export class EnvironmentManager {
 			}
 			return;
 		}
-		await this.pythonApi.environments.updateActiveEnvironmentPath(targetEnvironment.pythonPath);
-		logger.info(`Activated ${targetEnvironment.providerName} environment ${targetEnvironment.pythonPath}`);
-		await setTestingCwd(editor);
+		if (vscode.workspace.getWorkspaceFolder(editor.document.uri)) {
+			await this.pythonApi.environments.updateActiveEnvironmentPath(targetEnvironment.pythonPath);
+			logger.info(`Activated ${targetEnvironment.providerName} environment ${targetEnvironment.pythonPath}`);
+			await setTestingCwd(editor);
+		} else {
+			const root = paths.projectRoot(editor.document.uri.fsPath);
+			if (root) {
+				await workspace.create(vscode.Uri.file(root));
+			}
+		}
 	}
 }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -49,6 +49,7 @@ export class EnvironmentLookup {
 export class EnvironmentManager {
 	private readonly pythonApi: PythonExtension;
 	lookup: EnvironmentLookup;
+	readonly workspaceRoots: Set<string> = new Set<string>();
 
 	constructor(pythonApi: PythonExtension, lookup: EnvironmentLookup) {
 		this.pythonApi = pythonApi;
@@ -79,7 +80,8 @@ export class EnvironmentManager {
 			await setTestingCwd(editor);
 		} else {
 			const root = paths.projectRoot(editor.document.uri.fsPath);
-			if (root) {
+			if (root && (ignoreCache || !this.workspaceRoots.has(root))) {
+				this.workspaceRoots.add(root);
 				await workspace.create(vscode.Uri.file(root));
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const resetLookupCommand = vscode.commands.registerCommand('python-venv-switcher.resetLookup', async () => {
 		envManager.lookup = new EnvironmentLookup(await availableProviders());
+		envManager.workspaceRoots.clear();
 		envManager.setEnvironment(vscode.window.activeTextEditor, true);
 	});
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,38 @@
+import * as vscode from "vscode";
+import fs from "fs";
+import path from "path";
+import logger from "./logger";
+
+export type RootOptions = {
+    inWorkspace: boolean
+};
+
+function projectRoot(filePath: string, options?: RootOptions): string | undefined {
+    if (options?.inWorkspace && !vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath))) {
+        return undefined;
+    }
+    if (fs.existsSync(path.resolve(filePath, 'pyproject.toml'))) {
+        return filePath;
+    }
+    if (fs.existsSync(path.resolve(filePath, 'Pipfile'))) {
+        return filePath;
+    }
+    if (path.parse(filePath).root === filePath) {
+        return undefined;
+    }
+    return projectRoot(path.resolve(filePath, '..'), options);
+}
+
+function cwd(template: string, projectRoot: string): string | undefined {
+    const result = template.replaceAll('${projectRoot}', projectRoot);
+    if (!fs.existsSync(result)) {
+        logger.info(`Test directory ${result} not found`);
+        return undefined;
+    }
+    return result;
+}
+
+export default {
+    projectRoot,
+    cwd
+};

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,29 +1,6 @@
 import * as vscode from "vscode";
-import path from "path";
-import fs from "fs";
 import logger from "./logger";
-
-function projectRoot(filePath: string): string | undefined {
-    if (!vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath))) {
-        return undefined;
-    }
-    if (fs.existsSync(path.resolve(filePath, 'pyproject.toml'))) {
-        return filePath;
-    }
-    if (fs.existsSync(path.resolve(filePath, 'Pipfile'))) {
-        return filePath;
-    }
-    return projectRoot(path.resolve(filePath, '..'));
-}
-
-function cwd(template: string, projectRoot: string): string | undefined {
-    const result = template.replaceAll('${projectRoot}', projectRoot);
-    if (!fs.existsSync(result)) {
-        logger.info(`Test directory ${result} not found`);
-        return undefined;
-    }
-    return result;
-}
+import paths from "./paths";
 
 export async function setTestingCwd(editor?: vscode.TextEditor) {
     if (!editor) { return; }
@@ -35,8 +12,8 @@ export async function setTestingCwd(editor?: vscode.TextEditor) {
         return;
     }
 
-    const root = projectRoot(editor.document.uri.fsPath);
-    const testsDir = root ? cwd(template, root) : undefined;
+    const root = paths.projectRoot(editor.document.uri.fsPath, { inWorkspace: true });
+    const testsDir = root ? paths.cwd(template, root) : undefined;
     await testing.update('cwd', testsDir);
     logger.info(`Set python.testing.cwdTemplate to ${testsDir}`);
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+async function create(root: vscode.Uri) {
+    const switcher = vscode.workspace.getConfiguration('python.venv.switcher');
+    const createPreference = switcher.get<string>('createWorkspace');
+    if (createPreference === 'never') return;
+    const response = createPreference === 'always'
+        ? 'Create Workspace'
+        : await vscode.window.showInformationMessage(
+            'Virtual environment found. To activate the environment, create or open a workspace.',
+            'Create Workspace',
+            'Do not show again',
+        );
+    if (response === 'Create Workspace') {
+        vscode.workspace.updateWorkspaceFolders(0, 0, { uri: root });
+    } else if (response === 'Do not show again') {
+        switcher.update('createWorkspace', 'never', vscode.ConfigurationTarget.Global);
+    }
+}
+
+export default {
+    create
+};


### PR DESCRIPTION
VS Code will only allow extensions to set the Python interpreter if a workspace is open. If no workspace is open, the operation silently fails.

To workaround this limitation, Venv Switcher will now display a notification that offers to create a new workspace if needed. The notification will be shown once per detected environment root. Notifications can be disabled globally by clicking Do not show again in the notification or changing the Create Workspace setting to never. Workspaces can be created automatically by changing the Create Workspace setting to always.